### PR TITLE
fix: CSS HMR duplication

### DIFF
--- a/src/transformCSS.ts
+++ b/src/transformCSS.ts
@@ -7,11 +7,6 @@ import { updateStyle, removeStyle } from "/@vite/client"
 const id = "${opts.path}";
 const css = "${opts.code.replace(/\n/g, '')}";
 
-const style = document.createElement('style');
-style.setAttribute('type', 'text/css');
-style.innerHTML = css;
-document.head.appendChild(style);
-
 updateStyle(id, css);
 import.meta.hot.accept();
 export default css;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/23615778/121153441-a7b1a500-c878-11eb-8a54-8aec42c2916f.png)

这段代码导致每次 HMR 都会重新插一段 CSS 到 head 里，其实 `updateStyle` 函数已经做了这个逻辑了，好像可以删除？